### PR TITLE
feat(NOD-375): adds in helper function transformToMatchMap + abstracted utils

### DIFF
--- a/src/util/transformToMatchMap.test.ts
+++ b/src/util/transformToMatchMap.test.ts
@@ -1,0 +1,108 @@
+import {
+  parseMatchId,
+  parsePlayerNames,
+  parseRallyResult,
+  mapRallyResultToRallyAction,
+  transformToMatchMap,
+} from './transformToMatchMap'
+
+describe('transformToMatchMap', () => {
+  describe('helper functions', () => {
+    describe('parseMatchId', () => {
+      test('should return the match id', () => {
+        expect(parseMatchId('Match: 01')).toEqual('01')
+      })
+
+      test('should raise error if the argument has an invalid format', () => {
+        const fn = () => parseMatchId('01')
+        expect(fn).toThrow('Unexpected match id format: 01')
+      })
+    })
+
+    describe('parsePlayerNames', () => {
+      test('should return an array with player names', () => {
+        expect(parsePlayerNames('Person A vs Person B')).toEqual([
+          'Person A',
+          'Person B',
+        ])
+      })
+
+      test('should raise error if the argument has an invalid format', () => {
+        const fn = () => parsePlayerNames('Person A Person B')
+        expect(fn).toThrow('Unexpected player name format: Person A Person B')
+      })
+
+      test('should raise error if the argument has an invalid length of players', () => {
+        const fn = () => parsePlayerNames('Person A vs Person B vs Player C')
+        expect(fn).toThrow('Unexpected length of player names arr: 3')
+      })
+    })
+
+    describe('mapRallyResultToRallyAction', () => {
+      test('should return PLAYER_ONE_WIN type of case 0', () => {
+        expect(mapRallyResultToRallyAction('0')).toEqual({
+          type: 'PLAYER_ONE_WIN',
+        })
+      })
+
+      test('should return PLAYER_TWO_WIN type of case 1', () => {
+        expect(mapRallyResultToRallyAction('1')).toEqual({
+          type: 'PLAYER_TWO_WIN',
+        })
+      })
+
+      test('should raise error if the argument has an invalid length of players', () => {
+        const fn = () => mapRallyResultToRallyAction('3')
+        expect(fn).toThrow('Unexpected rally result: 3')
+      })
+    })
+
+    describe('parseRallyResult', () => {
+      test('should return 0 or 1 for a valid result', () => {
+        expect(parseRallyResult('1')).toEqual('1')
+        expect(parseRallyResult('0')).toEqual('0')
+      })
+
+      test('should raise error if the argument has an invalid format', () => {
+        const fn = () => parseRallyResult('3')
+
+        // Note: We expect index 1 after cleaning the empty strings
+        expect(fn).toThrow('Unexpected rally result: 3')
+      })
+    })
+  })
+
+  test('should return an array of Match objects', () => {
+    expect(transformToMatchMap(EXAMPLE_INPUT)).toEqual({
+      id: '01',
+      playerOne: 'Person A',
+      playerTwo: 'Person B',
+      rallyResults: ['0', '1', '1', '0', '0'],
+      rallyActions: [
+        {
+          type: 'PLAYER_ONE_WIN',
+        },
+        {
+          type: 'PLAYER_TWO_WIN',
+        },
+        {
+          type: 'PLAYER_TWO_WIN',
+        },
+        {
+          type: 'PLAYER_ONE_WIN',
+        },
+        {
+          type: 'PLAYER_ONE_WIN',
+        },
+      ],
+    })
+  })
+})
+
+const EXAMPLE_INPUT = `Match: 01
+Person A vs Person B
+0
+1
+1
+0
+0`

--- a/src/util/transformToMatchMap.ts
+++ b/src/util/transformToMatchMap.ts
@@ -1,0 +1,111 @@
+type RallyAction =
+  | {
+      type: 'PLAYER_ONE_WIN'
+    }
+  | {
+      type: 'PLAYER_TWO_WIN'
+    }
+
+export type Match = {
+  // Provided Match id
+  id: string
+  // Name of the first player
+  playerOne: string
+  // Name of the second player
+  playerTwo: string
+  // 0s and 1s turned into a string array
+  rallyResults: string[]
+  // An array of Rally objects
+  rallyActions: RallyAction[]
+}
+
+/**
+ * Parses valid input to get the match ID.
+ * @example
+ * parseMatchId('Match: 01') // '01'
+ */
+export function parseMatchId(matchIdStr: string): string {
+  if (!matchIdStr.includes('Match: ')) {
+    throw new Error(`Unexpected match id format: ${matchIdStr}`)
+  }
+
+  return matchIdStr.split('Match: ')[1]
+}
+
+/**
+ * Parses valid input to get the player names. Returned as a tuple.
+ * @example
+ * parsePlayerNames('Person A vs Person B') // ['Person A', 'Person B']
+ */
+export function parsePlayerNames(playerNamesStr: string): [string, string] {
+  if (!playerNamesStr.includes(' vs ')) {
+    throw new Error(`Unexpected player name format: ${playerNamesStr}`)
+  }
+
+  const playerNameArr = playerNamesStr.split(' vs ')
+  if (playerNameArr.length !== 2) {
+    throw new Error(
+      `Unexpected length of player names arr: ${playerNameArr.length}`
+    )
+  }
+
+  const [playerOne, playerTwo] = playerNameArr
+  return [playerOne, playerTwo]
+}
+
+/**
+ * Parses valid input to get the rally result.
+ * @example
+ * parseRallyResult('1') // '1'
+ */
+export function parseRallyResult(rallyResult: string): '0' | '1' {
+  const rallyResultCleaned = rallyResult.trim()
+
+  if (rallyResultCleaned !== '0' && rallyResultCleaned !== '1') {
+    throw new Error(`Unexpected rally result: ${rallyResultCleaned}`)
+  }
+
+  return rallyResultCleaned
+}
+
+/**
+ * Maps a rally result to a RallyAction.
+ * @example
+ * mapRallyResultToRallyAction('0') // { type: 'PLAYER_ONE_WIN' }
+ */
+export function mapRallyResultToRallyAction(rallyResult: string): RallyAction {
+  switch (rallyResult) {
+    case '0':
+      return {
+        type: 'PLAYER_ONE_WIN',
+      }
+    case '1':
+      return {
+        type: 'PLAYER_TWO_WIN',
+      }
+    default:
+      throw new Error(`Unexpected rally result: ${rallyResult}`)
+  }
+}
+
+/**
+ * Takes valid string input for a match and returns an object to represent the match.
+ */
+export function transformToMatchMap(match: string): Match {
+  const [matchIdStr, playerNamesStr, ...rallyResultsArr] = match.split('\n')
+
+  const matchId = parseMatchId(matchIdStr)
+  const [playerOne, playerTwo] = parsePlayerNames(playerNamesStr)
+  const rallyResults = rallyResultsArr
+    .filter((rallyResult) => rallyResult !== '')
+    .map(parseRallyResult)
+  const rallyActions = rallyResults.map(mapRallyResultToRallyAction)
+
+  return {
+    id: matchId,
+    playerOne,
+    playerTwo,
+    rallyResults,
+    rallyActions,
+  }
+}


### PR DESCRIPTION
## Linear tickets

- [Fixes NOD-375](https://linear.app/nodular/issue/NOD-375)

See attached ticket(s) for more details.

## Branch changelog

### Features

- feat(NOD-375): adds in helper function transformToMatchMap + abstracted utilities [3d132d9](https://github.com/okeeffed/tennis-results-cli/commit/3d132d9fffabebaab7c187fa03be233dab076ece)

### Fixes

No fixes reported.

### Chores

No chores reported.

### Other changes

- Merge pull request #2 from okeeffed/feature/nod-375-feature-add-transformtomatchmap-functionality [ba50ca1](https://github.com/okeeffed/tennis-results-cli/commit/ba50ca1f69596f925f14015515013ff5dde8055c)
