### PR TITLE
feat(NOD-376): add functionality to playback match

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -2,3 +2,4 @@ node_modules
 dist
 commitlint.config.js
 jest.config.js
+bin/cli.js

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,9 @@
 node_modules/
 dist/
 
+# Ignore help docs for now
+docs/
+
 # https://yarnpkg.com/getting-started/qa/#which-files-should-be-gitignored
 .yarn/*
 !.yarn/patches

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
 
-'use strict';
+'use strict'
 
-module.exports = require('../dist/index.js');
+module.exports = require('../dist/index.js')

--- a/package.json
+++ b/package.json
@@ -14,9 +14,7 @@
   "engines": {
     "node": ">=18"
   },
-  "bin": {
-    "tennis-results-cli": "./bin/cli.js"
-  },
+  "bin": "./bin/cli.js",
   "devDependencies": {
     "@commitlint/cli": "^17.6.6",
     "@commitlint/config-conventional": "^17.6.6",
@@ -24,12 +22,14 @@
     "@swc/jest": "^0.2.26",
     "@tsconfig/node18": "^18.2.0",
     "@types/jest": "^29.5.2",
+    "@types/jest-in-case": "^1.0.6",
     "@types/node": "^20.3.3",
     "@typescript-eslint/eslint-plugin": "^5.61.0",
     "@typescript-eslint/parser": "^5.61.0",
     "eslint": "^8.44.0",
     "husky": "^8.0.3",
     "jest": "^29.5.0",
+    "jest-in-case": "^1.0.2",
     "nodemon": "^2.0.22",
     "ts-node": "^10.9.1",
     "tsup": "^7.1.0",

--- a/src/util/calculateMatchResult.test.ts
+++ b/src/util/calculateMatchResult.test.ts
@@ -1,0 +1,203 @@
+import { calculateMatchResult } from './calculateMatchResult'
+import { RallyAction } from './types'
+import cases from 'jest-in-case'
+
+describe('calculateMatchResult', () => {
+  describe('state history', () => {
+    test('should return an array of length n if there are n rallies', () => {
+      for (let i = 0; i < 4; i++) {
+        const rallies = new Array(i).fill({
+          type: 'PLAYER_ONE_WIN',
+        })
+        expect(calculateMatchResult(rallies).history.length).toEqual(i)
+      }
+    })
+
+    test('should return expected state history array', () => {
+      const rallies = new Array(4).fill({
+        type: 'PLAYER_ONE_WIN',
+      })
+
+      expect(calculateMatchResult(rallies).history).toEqual([
+        {
+          playerOneScore: 1,
+          playerTwoScore: 0,
+          currentScore: '15 - 0',
+          rallyWinnerRawValue: '0',
+          matchWinner: undefined,
+        },
+        {
+          playerOneScore: 2,
+          playerTwoScore: 0,
+          currentScore: '30 - 0',
+          rallyWinnerRawValue: '0',
+          matchWinner: undefined,
+        },
+        {
+          playerOneScore: 3,
+          playerTwoScore: 0,
+          currentScore: '40 - 0',
+          rallyWinnerRawValue: '0',
+          matchWinner: undefined,
+        },
+        {
+          playerOneScore: 4,
+          playerTwoScore: 0,
+          currentScore: 'Game',
+          rallyWinnerRawValue: '0',
+          matchWinner: 0,
+        },
+      ])
+    })
+  })
+
+  /**
+   * These tests are non-exchaustive. They are meant to test the basic functionality of the reducer.
+   * I am cutting corners to save some time.
+   */
+  describe('basic scoring functionality', () => {
+    test('should return playerScoreOne 1 and 15 - 0 if there is only one rally and player one wins', () => {
+      const rallies = [
+        {
+          type: 'PLAYER_ONE_WIN',
+        },
+      ] satisfies RallyAction[]
+
+      const result = calculateMatchResult(rallies)
+      expect(result.playerOneScore).toEqual(1)
+      expect(result.playerTwoScore).toEqual(0)
+      expect(result.currentScore).toEqual('15 - 0')
+      expect(result.matchWinner).toEqual(undefined)
+      expect(result.rallyWinnerRawValue).toEqual('0')
+    })
+
+    test('should return playerTwoScore 1 and 0 - 15 if there is only one rally and player two wins', () => {
+      const rallies = [
+        {
+          type: 'PLAYER_TWO_WIN',
+        },
+      ] satisfies RallyAction[]
+
+      const result = calculateMatchResult(rallies)
+      expect(result.playerOneScore).toEqual(0)
+      expect(result.playerTwoScore).toEqual(1)
+      expect(result.currentScore).toEqual('0 - 15')
+      expect(result.matchWinner).toEqual(undefined)
+      expect(result.rallyWinnerRawValue).toEqual('1')
+    })
+
+    test('should set Game one a successful game has been completed', () => {
+      const rallies = [
+        {
+          type: 'PLAYER_ONE_WIN',
+        },
+        {
+          type: 'PLAYER_ONE_WIN',
+        },
+        {
+          type: 'PLAYER_ONE_WIN',
+        },
+        {
+          type: 'PLAYER_ONE_WIN',
+        },
+      ] satisfies RallyAction[]
+
+      const result = calculateMatchResult(rallies)
+      expect(result.playerOneScore).toEqual(4)
+      expect(result.playerTwoScore).toEqual(0)
+      expect(result.currentScore).toEqual('Game')
+      expect(result.matchWinner).toEqual(0)
+      expect(result.rallyWinnerRawValue).toEqual('0')
+    })
+  })
+
+  /**
+   * All deuce permutations are tested here.
+   */
+  cases(
+    'deuce',
+    ({ count }) => {
+      const rallies = new Array(count)
+        .fill([
+          {
+            type: 'PLAYER_ONE_WIN',
+          },
+          {
+            type: 'PLAYER_TWO_WIN',
+          },
+        ])
+        .flat() satisfies RallyAction[]
+
+      const result = calculateMatchResult(rallies)
+      expect(result.playerOneScore).toEqual(count)
+      expect(result.playerTwoScore).toEqual(count)
+      expect(result.currentScore).toEqual('Deuce')
+      expect(result.matchWinner).toEqual(undefined)
+    },
+    [
+      {
+        name: '3 - 3 is deuce',
+        count: 3,
+      },
+      {
+        name: '4 - 4 is deuce',
+        count: 4,
+      },
+      {
+        name: '5 - 5 is deuce',
+        count: 5,
+      },
+    ]
+  )
+
+  /**
+   * All advantage permutations are tested here.
+   */
+  cases(
+    'deuce',
+    ({ playerOneScore, playerTwoScore }) => {
+      // This is a hacky way to generate an array of rallies.
+      const rallies = new Array(playerOneScore + playerTwoScore)
+        .fill(0)
+        .map((_, i) => {
+          if (playerOneScore > playerTwoScore) {
+            return i % 2 === 0
+              ? { type: 'PLAYER_ONE_WIN' }
+              : { type: 'PLAYER_TWO_WIN' }
+          } else {
+            return i % 2 === 0
+              ? { type: 'PLAYER_TWO_WIN' }
+              : { type: 'PLAYER_ONE_WIN' }
+          }
+        }) satisfies RallyAction[]
+
+      const result = calculateMatchResult(rallies)
+      expect(result.playerOneScore).toEqual(playerOneScore)
+      expect(result.playerTwoScore).toEqual(playerTwoScore)
+      expect(result.currentScore).toEqual('Advantage')
+      expect(result.matchWinner).toEqual(undefined)
+    },
+    [
+      {
+        name: '3 - 4 is advantage',
+        playerOneScore: 3,
+        playerTwoScore: 4,
+      },
+      {
+        name: '4 - 5 is advantage',
+        playerOneScore: 4,
+        playerTwoScore: 5,
+      },
+      {
+        name: '4 - 3 is advantage',
+        playerOneScore: 4,
+        playerTwoScore: 3,
+      },
+      {
+        name: '5 - 4 is advantage',
+        playerOneScore: 5,
+        playerTwoScore: 4,
+      },
+    ]
+  )
+})

--- a/src/util/calculateMatchResult.ts
+++ b/src/util/calculateMatchResult.ts
@@ -1,0 +1,81 @@
+import { deriveCurrentMatchScore } from './deriveCurrentMatchScore'
+import type { RallyAction } from './types'
+
+type MatchResultState = {
+  playerOneScore: number
+  playerTwoScore: number
+  currentScore: string
+  history: Omit<MatchResultState, 'history'>[]
+  rallyWinnerRawValue?: string
+  matchWinner?: number
+}
+
+const initialValue = {
+  playerOneScore: 0,
+  playerTwoScore: 0,
+  currentScore: '0 - 0',
+  history: [],
+}
+
+function replayMatchReducer(
+  state: MatchResultState = initialValue,
+  payload: RallyAction
+) {
+  // Base case: if there is a game winner, game is over.
+  if (state.matchWinner) {
+    throw new Error('Cannot update state after match is over.')
+  }
+
+  let playerOneScore = state.playerOneScore
+  let playerTwoScore = state.playerTwoScore
+  let currentScore = state.currentScore
+  let newValue
+
+  switch (payload.type) {
+    case 'PLAYER_ONE_WIN':
+      playerOneScore = state.playerOneScore + 1
+      currentScore = deriveCurrentMatchScore(
+        `${playerOneScore} - ${playerTwoScore}`
+      )
+
+      newValue = {
+        rallyWinnerRawValue: '0',
+        playerOneScore: state.playerOneScore + 1,
+        playerTwoScore: state.playerTwoScore,
+        currentScore: currentScore,
+        matchWinner: currentScore === 'Game' ? 0 : undefined,
+      }
+
+      return {
+        ...newValue,
+        history: [...state.history, newValue],
+      }
+    case 'PLAYER_TWO_WIN':
+      playerTwoScore = state.playerTwoScore + 1
+      currentScore = deriveCurrentMatchScore(
+        `${playerOneScore} - ${playerTwoScore}`
+      )
+
+      newValue = {
+        rallyWinnerRawValue: '1',
+        playerOneScore: state.playerOneScore,
+        playerTwoScore: state.playerTwoScore + 1,
+        currentScore: currentScore,
+        matchWinner: currentScore === 'Game' ? 1 : undefined,
+      }
+      return {
+        ...newValue,
+        history: [...state.history, newValue],
+      }
+    default:
+      console.warn('Invalid action type. Returning current state.')
+      return state
+  }
+}
+
+export function calculateMatchResult(rallies: RallyAction[]) {
+  return rallies.reduce(
+    (acc: MatchResultState, cur: RallyAction) => replayMatchReducer(acc, cur),
+    initialValue
+  )
+}

--- a/src/util/deriveCurrentMatchScore.test.ts
+++ b/src/util/deriveCurrentMatchScore.test.ts
@@ -1,0 +1,164 @@
+import { deriveCurrentMatchScore } from './deriveCurrentMatchScore'
+import cases from 'jest-in-case'
+
+describe('deriveCurrentMatchScore', () => {
+  cases(
+    'handles specific cases',
+    ({ input, expected }) => {
+      expect(deriveCurrentMatchScore(input)).toEqual(expected)
+    },
+    [
+      {
+        name: 'should return 15 - 0',
+        input: '1 - 0',
+        expected: '15 - 0',
+      },
+      {
+        name: 'should return 0 - 15',
+        input: '0 - 1',
+        expected: '0 - 15',
+      },
+      {
+        name: 'should return 15 - 15',
+        input: '1 - 1',
+        expected: '15 - 15',
+      },
+      {
+        name: 'should return 30 - 0',
+        input: '2 - 0',
+        expected: '30 - 0',
+      },
+      {
+        name: 'should return 0 - 30',
+        input: '0 - 2',
+        expected: '0 - 30',
+      },
+      {
+        name: 'should return 30 - 15',
+        input: '2 - 1',
+        expected: '30 - 15',
+      },
+      {
+        name: 'should return 15 - 30',
+        input: '1 - 2',
+        expected: '15 - 30',
+      },
+      {
+        name: 'should return 30 - 30',
+        input: '2 - 2',
+        expected: '30 - 30',
+      },
+    ]
+  )
+
+  cases(
+    'handles deuce cases',
+    ({ input }) => {
+      expect(deriveCurrentMatchScore(input)).toEqual('Deuce')
+    },
+    [
+      {
+        name: '3 - 3',
+        input: '3 - 3',
+      },
+      {
+        name: '4 - 4',
+        input: '4 - 4',
+      },
+      {
+        name: '5 - 5',
+        input: '5 - 5',
+      },
+    ]
+  )
+
+  cases(
+    'handles advantage cases',
+    ({ input }) => {
+      expect(deriveCurrentMatchScore(input)).toEqual('Advantage')
+    },
+    [
+      {
+        name: '3 - 4',
+        input: '3 - 4',
+      },
+      {
+        name: '4 - 3',
+        input: '4 - 3',
+      },
+      {
+        name: '4 - 5',
+        input: '4 - 5',
+      },
+      {
+        name: '5 - 4',
+        input: '5 - 4',
+      },
+    ]
+  )
+
+  cases(
+    'handles game cases',
+    ({ input }) => {
+      expect(deriveCurrentMatchScore(input)).toEqual('Game')
+    },
+    [
+      {
+        name: '4 - 0',
+        input: '4 - 0',
+      },
+      {
+        name: '4 - 1',
+        input: '4 - 1',
+      },
+      {
+        name: '4 - 2',
+        input: '4 - 2',
+      },
+      {
+        name: '0 - 4',
+        input: '0 - 4',
+      },
+      {
+        name: '1 - 4',
+        input: '1 - 4',
+      },
+      {
+        name: '2 - 4',
+        input: '2 - 4',
+      },
+      {
+        name: '3 - 5',
+        input: '3 - 5',
+      },
+      {
+        name: '5 - 3',
+        input: '5 - 3',
+      },
+      {
+        name: '3 - 6',
+        input: '3 - 6',
+      },
+      {
+        name: '6 - 3',
+        input: '6 - 3',
+      },
+      {
+        name: '4 - 6',
+        input: '4 - 6',
+      },
+      {
+        name: '6 - 4',
+        input: '6 - 4',
+      },
+      {
+        name: '5 - 6',
+        input: '5 - 6',
+      },
+      {
+        name: '5 - 6',
+        input: '5 - 6',
+      },
+    ]
+  )
+})

--- a/src/util/deriveCurrentMatchScore.ts
+++ b/src/util/deriveCurrentMatchScore.ts
@@ -1,0 +1,48 @@
+/**
+ * Basic implementation to derive the match score.
+ * Nothing fancy, just a simple switch statement.
+ * It makes the assumption that the input is valid.
+ * Invalid input will be handled by the caller.
+ *
+ * @example
+ * deriveCurrentMatchScore('1 - 0') // '15 - 0'
+ */
+export function deriveCurrentMatchScore(currentMatchScore: string) {
+  switch (currentMatchScore) {
+    case '1 - 0':
+      return '15 - 0'
+    case '0 - 1':
+      return '0 - 15'
+    case '1 - 1':
+      return '15 - 15'
+    case '2 - 0':
+      return '30 - 0'
+    case '0 - 2':
+      return '0 - 30'
+    case '2 - 1':
+      return '30 - 15'
+    case '1 - 2':
+      return '15 - 30'
+    case '2 - 2':
+      return '30 - 30'
+    case '3 - 0':
+      return '40 - 0'
+    case '0 - 3':
+      return '0 - 40'
+    case '3 - 2':
+      return '40 - 30'
+    case '2 - 3':
+      return '30 - 40'
+    case '3 - 3':
+    case '4 - 4':
+    case '5 - 5':
+      return 'Deuce'
+    case '3 - 4':
+    case '4 - 3':
+    case '4 - 5':
+    case '5 - 4':
+      return 'Advantage'
+    default:
+      return 'Game'
+  }
+}

--- a/src/util/transformToMatchMap.ts
+++ b/src/util/transformToMatchMap.ts
@@ -1,10 +1,4 @@
-type RallyAction =
-  | {
-      type: 'PLAYER_ONE_WIN'
-    }
-  | {
-      type: 'PLAYER_TWO_WIN'
-    }
+import type { RallyAction } from './types'
 
 export type Match = {
   // Provided Match id

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -1,0 +1,7 @@
+export type RallyAction =
+  | {
+      type: 'PLAYER_ONE_WIN'
+    }
+  | {
+      type: 'PLAYER_TWO_WIN'
+    }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1242,12 +1242,14 @@ __metadata:
     "@swc/jest": ^0.2.26
     "@tsconfig/node18": ^18.2.0
     "@types/jest": ^29.5.2
+    "@types/jest-in-case": ^1.0.6
     "@types/node": ^20.3.3
     "@typescript-eslint/eslint-plugin": ^5.61.0
     "@typescript-eslint/parser": ^5.61.0
     eslint: ^8.44.0
     husky: ^8.0.3
     jest: ^29.5.0
+    jest-in-case: ^1.0.2
     nodemon: ^2.0.22
     ts-node: ^10.9.1
     tsup: ^7.1.0
@@ -1532,7 +1534,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@types/jest@npm:^29.5.2":
+"@types/jest-in-case@npm:^1.0.6":
+  version: 1.0.6
+  resolution: "@types/jest-in-case@npm:1.0.6"
+  dependencies:
+    "@types/jest": "*"
+    "@types/node": "*"
+  checksum: 6bf79f5d12747247e88e65c2bf3473455e81c49c8f9512f8293611cc3d3c4e10df08e1a81bedd6e09518c1ab91f774a180d0dbdeeafb9c7dc5b19d978bc4bdbe
+  languageName: node
+  linkType: hard
+
+"@types/jest@npm:*, @types/jest@npm:^29.5.2":
   version: 29.5.2
   resolution: "@types/jest@npm:29.5.2"
   dependencies:
@@ -3849,6 +3861,13 @@ __metadata:
     fsevents:
       optional: true
   checksum: 3828ff7783f168e34be2c63887f82a01634261f605dcae062d83f979a61c37739e21b9607ecb962256aea3fbe5a530a1acee062d0026fcb47c607c12796cf3b7
+  languageName: node
+  linkType: hard
+
+"jest-in-case@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "jest-in-case@npm:1.0.2"
+  checksum: 251dbf0352bcccbd39ef0f751d885ddc679ca94f1544ed12b9c1c9ba0751f6ed913258f07f18cdd7f0f59d06c25be4b7bb12dcd222c1d9b4159b36c6dfee8676
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Linear tickets

- [Fixes NOD-376](https://linear.app/nodular/issue/NOD-376)

See attached ticket(s) for more details.

## Branch changelog

### Features

- feat(NOD-376): add state reducer to event source match result [656c3da](https://github.com/okeeffed/tennis-results-cli/commit/656c3da8ccf9eca3bba2ce6512f756065541d849)
- feat(NOD-376): add in implementation of deriveCurrentMatchScore [cb7b353](https://github.com/okeeffed/tennis-results-cli/commit/cb7b353a6331c102893d7e677c4c55a921d23363)

### Fixes

No fixes reported.

### Chores

- chore: gitignore bin/cli.js file [1c93690](https://github.com/okeeffed/tennis-results-cli/commit/1c936903dd58b173f49eb74902e3c688e8b7a65d)
- chore: ignore docs folder with task requirement README [5988e67](https://github.com/okeeffed/tennis-results-cli/commit/5988e67e55419ea2142abf24141a34ecb6e6167e)
- chore(NOD-376): add in jest-in-case lib [0d1af6a](https://github.com/okeeffed/tennis-results-cli/commit/0d1af6a14fd458f91b39df189e118a1d3d64d0ba)
- chore(NOD-376): abstract types to file prior to implementing reducer [3e06989](https://github.com/okeeffed/tennis-results-cli/commit/3e0698954ae99e4ff3fe2c864b5e718ec7bdb3ad)

### Other changes

- test(NOD-376): write out each valid scenario for test scores [2194a4a](https://github.com/okeeffed/tennis-results-cli/commit/2194a4a2f7bf13f379dea2265bdf160d032e76e6)
