### PR TITLE
feat(nod-390): add queryMatchResults functionality

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,8 @@ module.exports = {
   transform: {
     '^.+\\.(t|j)sx?$': '@swc/jest',
   },
+  // Support same @ -> src alias mapping as tsconfig defines
+  moduleNameMapper: {
+    '^@/(.*)$': '<rootDir>/src/$1',
+  },
 }

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@swc/core": "^1.3.67",
     "@swc/jest": "^0.2.26",
     "@tsconfig/node18": "^18.2.0",
+    "@types/cli-table": "^0.3.1",
     "@types/jest": "^29.5.2",
     "@types/jest-in-case": "^1.0.6",
     "@types/node": "^20.3.3",
@@ -45,5 +46,8 @@
     "deploy": "npm run build && npm run install:npm",
     "dedupe-check": "bin/dedupe-check"
   },
-  "packageManager": "yarn@3.6.1"
+  "packageManager": "yarn@3.6.1",
+  "dependencies": {
+    "cli-table": "^0.3.11"
+  }
 }

--- a/src/queries/queryMatchResult.test.ts
+++ b/src/queries/queryMatchResult.test.ts
@@ -1,0 +1,24 @@
+import { Match } from '@/util/types'
+import { queryMatchResult } from './queryMatchResult'
+
+describe('queryMatchResult', () => {
+  test('it should print the expected match result', () => {
+    // Mock implementation so it does not log results
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(jest.fn)
+
+    const match = {
+      id: '01',
+      playerOne: 'Person A',
+      playerTwo: 'Person B',
+      rallyResults: new Array(8).fill('0'),
+      rallyActions: new Array(8).fill({
+        type: 'PLAYER_ONE_WIN',
+      }),
+    } satisfies Match
+
+    queryMatchResult(match)
+    expect(logSpy).toHaveBeenCalledWith('Person A defeated Person B')
+    expect(logSpy).toHaveBeenCalledWith('2 sets to 0')
+    logSpy.mockRestore()
+  })
+})

--- a/src/queries/queryMatchResult.test.ts
+++ b/src/queries/queryMatchResult.test.ts
@@ -1,24 +1,67 @@
 import { Match } from '@/util/types'
 import { queryMatchResult } from './queryMatchResult'
+import { debugMatchLedger } from '@/util/debugMatchLedger'
+import { calculateMatchResult } from '@/util/calculateMatchResult'
+
+jest.mock('@/util/debugMatchLedger', () => ({
+  debugMatchLedger: jest.fn(),
+}))
 
 describe('queryMatchResult', () => {
-  test('it should print the expected match result', () => {
+  test('it should print the expected match result and not call debugMatchLedger when debug is false', () => {
     // Mock implementation so it does not log results
     const logSpy = jest.spyOn(console, 'log').mockImplementation(jest.fn)
-
+    const rallyResults = ['0', '1', '0', '1', '0', '0', '0', '0', '0', '0']
     const match = {
       id: '01',
       playerOne: 'Person A',
       playerTwo: 'Person B',
-      rallyResults: new Array(8).fill('0'),
-      rallyActions: new Array(8).fill({
-        type: 'PLAYER_ONE_WIN',
+      rallyResults,
+      rallyActions: rallyResults.map((result) => {
+        return result === '0'
+          ? { type: 'PLAYER_ONE_WIN' }
+          : { type: 'PLAYER_TWO_WIN' }
       }),
     } satisfies Match
 
-    queryMatchResult(match)
+    queryMatchResult(match, false)
+
     expect(logSpy).toHaveBeenCalledWith('Person A defeated Person B')
     expect(logSpy).toHaveBeenCalledWith('2 sets to 0')
     logSpy.mockRestore()
+
+    // Verify that the debugMatchLedger function was called
+    // instead of attempt to the complicated string.
+    expect(debugMatchLedger).not.toHaveBeenCalled()
+  })
+
+  test('it should print the expected match result and call debugMatchLedger when debug is true', () => {
+    // Mock implementation so it does not log results
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(jest.fn)
+    const rallyResults = ['0', '1', '0', '1', '0', '0', '0', '0', '0', '0']
+    const match = {
+      id: '01',
+      playerOne: 'Person A',
+      playerTwo: 'Person B',
+      rallyResults,
+      rallyActions: rallyResults.map((result) => {
+        return result === '0'
+          ? { type: 'PLAYER_ONE_WIN' }
+          : { type: 'PLAYER_TWO_WIN' }
+      }),
+    } satisfies Match
+
+    queryMatchResult(match, true)
+
+    expect(logSpy).toHaveBeenCalledWith('Person A defeated Person B')
+    expect(logSpy).toHaveBeenCalledWith('2 sets to 0')
+    logSpy.mockRestore()
+
+    // Verify that the debugMatchLedger function was called
+    // instead of attempt to the complicated string.
+    expect(debugMatchLedger).toHaveBeenCalledWith(
+      match,
+      calculateMatchResult(match.rallyActions).history
+    )
   })
 })

--- a/src/queries/queryMatchResult.ts
+++ b/src/queries/queryMatchResult.ts
@@ -1,0 +1,13 @@
+import type { Match } from '@/util/types'
+import { calculateMatchResult } from '@/util/calculateMatchResult'
+import { logMatchResults } from '@/util/logMatchResults'
+
+export function queryMatchResult(match: Match, debug = false): void {
+  const result = calculateMatchResult(match.rallyActions)
+
+  if (debug) {
+    // TODO: Add in debug fn to log match results
+  }
+
+  logMatchResults(match, result)
+}

--- a/src/queries/queryMatchResult.ts
+++ b/src/queries/queryMatchResult.ts
@@ -1,12 +1,13 @@
 import type { Match } from '@/util/types'
 import { calculateMatchResult } from '@/util/calculateMatchResult'
 import { logMatchResults } from '@/util/logMatchResults'
+import { debugMatchLedger } from '@/util/debugMatchLedger'
 
 export function queryMatchResult(match: Match, debug = false): void {
   const result = calculateMatchResult(match.rallyActions)
 
   if (debug) {
-    // TODO: Add in debug fn to log match results
+    debugMatchLedger(match, result.history)
   }
 
   logMatchResults(match, result)

--- a/src/util/debugMatchLedger.ts
+++ b/src/util/debugMatchLedger.ts
@@ -1,0 +1,28 @@
+import Table from 'cli-table'
+import { Match, MatchResultState } from './types'
+
+/**
+ * Prints a CLI table to help debug match results.
+ * It emulates what was given in the README.
+ */
+export function debugMatchLedger(
+  match: Match,
+  history: Omit<MatchResultState, 'history'>[]
+) {
+  const table = new Table({
+    head: ['Input', 'Score'],
+  })
+
+  table.push([`Match: ${match.id}`, ''])
+  table.push([`${match.playerOne} vs ${match.playerTwo}`, ''])
+
+  history.forEach((entry) => {
+    if (entry.rallyWinnerRawValue === undefined) {
+      throw new Error('Unexpected undefined rally winner.')
+    }
+
+    table.push([entry.rallyWinnerRawValue, entry.currentScore])
+  })
+
+  console.log(table.toString())
+}

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -27,6 +27,5 @@ export type MatchResultState = {
   currentScore: string
   history: Omit<MatchResultState, 'history'>[]
   rallyWinnerRawValue?: string
-  setWinner?: number
   matchWinner?: number
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,3 +1,9 @@
 {
-  "extends": "@tsconfig/node18/tsconfig.json"
+  "extends": "@tsconfig/node18/tsconfig.json",
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    }
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1241,11 +1241,13 @@ __metadata:
     "@swc/core": ^1.3.67
     "@swc/jest": ^0.2.26
     "@tsconfig/node18": ^18.2.0
+    "@types/cli-table": ^0.3.1
     "@types/jest": ^29.5.2
     "@types/jest-in-case": ^1.0.6
     "@types/node": ^20.3.3
     "@typescript-eslint/eslint-plugin": ^5.61.0
     "@typescript-eslint/parser": ^5.61.0
+    cli-table: ^0.3.11
     eslint: ^8.44.0
     husky: ^8.0.3
     jest: ^29.5.0
@@ -1497,6 +1499,13 @@ __metadata:
   dependencies:
     "@babel/types": ^7.20.7
   checksum: 58341e23c649c0eba134a1682d4f20d027fad290d92e5740faa1279978f6ed476fc467ae51ce17a877e2566d805aeac64eae541168994367761ec883a4150221
+  languageName: node
+  linkType: hard
+
+"@types/cli-table@npm:^0.3.1":
+  version: 0.3.1
+  resolution: "@types/cli-table@npm:0.3.1"
+  checksum: d6017999e3b800d9c36172faaad3177d71644aaa322d6e935ead62ca0f3b423776d58ab3a906c00935745a794778143e1f7577088789bbb4835b3986357bdd05
   languageName: node
   linkType: hard
 
@@ -2280,6 +2289,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"cli-table@npm:^0.3.11":
+  version: 0.3.11
+  resolution: "cli-table@npm:0.3.11"
+  dependencies:
+    colors: 1.0.3
+  checksum: 59fb61f992ac9bc8610ed98c72bf7f5d396c5afb42926b6747b46b0f8bb98a0dfa097998e77542ac334c1eb7c18dbf4f104d5783493273c5ec4c34084aa7c663
+  languageName: node
+  linkType: hard
+
 "cliui@npm:^8.0.1":
   version: 8.0.1
   resolution: "cliui@npm:8.0.1"
@@ -2343,6 +2361,13 @@ __metadata:
   bin:
     color-support: bin.js
   checksum: 9b7356817670b9a13a26ca5af1c21615463b500783b739b7634a0c2047c16cef4b2865d7576875c31c3cddf9dd621fa19285e628f20198b233a5cfdda6d0793b
+  languageName: node
+  linkType: hard
+
+"colors@npm:1.0.3":
+  version: 1.0.3
+  resolution: "colors@npm:1.0.3"
+  checksum: 234e8d3ab7e4003851cdd6a1f02eaa16dabc502ee5f4dc576ad7959c64b7477b15bd21177bab4055a4c0a66aa3d919753958030445f87c39a253d73b7a3637f5
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Changes

- Implements `queryMatchResults` in preparation for the CLI functionality.
- Adds a debugging helper to use down the track for debugging match results if required.

## Linear tickets

- [Fixes NOD-377](https://linear.app/nodular/issue/NOD-377)
- [Fixes NOD-390](https://linear.app/nodular/issue/NOD-390)

See attached ticket(s) for more details.

## Branch changelog

### Features

- feat(NOD-390): implement support for helper query to log out match results [6e2bf47](https://github.com/okeeffed/tennis-results-cli/commit/6e2bf471386f82338ca4b7d241c934cd35851cbb)

### Fixes

- fix: remove unused optional property on MatchResultState type [4c8d37c](https://github.com/okeeffed/tennis-results-cli/commit/4c8d37ce29ec46c3615469a996865d26bac4f4de)

### Chores

- chore(NOD-377): add debugging feature for queryMatchLedger [974090c](https://github.com/okeeffed/tennis-results-cli/commit/974090c86c87c14d228d5199b4505a9be3f8e96d)
- chore(NOD-377): install cli-table in preparation for debugging helper [ae21900](https://github.com/okeeffed/tennis-results-cli/commit/ae21900e99a9cee0c7767c22cebb5592a3cffcd8)
- chore: support @/ import paths for both Jest and TypeScript config [293ea46](https://github.com/okeeffed/tennis-results-cli/commit/293ea46b5791b39bd89983e99fb4f8dc27b7567a)

### Other changes

No other changes reported.
