### PR TITLE
feat(NOD-380): add ability to calculate win-loss and wire up CLI

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,9 @@
   "engines": {
     "node": ">=18"
   },
-  "bin": "./bin/cli.js",
+  "bin": {
+    "tennis-results-cli": "./bin/cli.js"
+  },
   "devDependencies": {
     "@commitlint/cli": "^17.6.6",
     "@commitlint/config-conventional": "^17.6.6",
@@ -43,7 +45,7 @@
     "type-check": "tsc --noEmit",
     "lint": "eslint . --ext .ts",
     "build": "tsup src/index.ts --dts --format esm,cjs",
-    "install:npm": "npm uninstall -g . && npm i --force -g . && google-search-console help",
+    "install:npm": "npm uninstall -g . && npm i --force -g . && tennis-results-cli --help",
     "deploy": "npm run build && npm run install:npm",
     "dedupe-check": "bin/dedupe-check"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,7 @@ import type { Match } from '@/util/types'
 import { queryMatchResult } from '@/queries/queryMatchResult'
 import path from 'path'
 import { argv } from '@/util/argv'
+import { queryPlayerWinLoss } from './queries/queryPlayerWinLoss'
 
 const TARGET_FILE = 'tournaments/full_tournament_valid.txt'
 const HELP = `
@@ -34,7 +35,12 @@ function delegateToCommand({
     queryMatchResult(match, argv.debug || argv.d)
   } else if (/Games Player/.test(input)) {
     const player = input.split('Games Player ')[1]
-    console.log(player)
+
+    if (!player) {
+      throw new Error(`Player not found: ${player}`)
+    }
+
+    queryPlayerWinLoss(matches, player, argv.debug || argv.d)
   } else {
     throw new Error(`Unexpected input: ${input}`)
   }
@@ -84,7 +90,13 @@ function main() {
   })
 
   if (argv.dev) {
-    const fallbackInput = ['Score Match 01', 'Score Match 02']
+    const fallbackInput = [
+      'Score Match 01',
+      'Score Match 02',
+      'Games Player Person A',
+      'Games Player Person B',
+      'Games Player Person C',
+    ]
     fallbackInput.map((line) =>
       delegateToCommand({
         input: line,

--- a/src/queries/queryMatchResult.test.ts
+++ b/src/queries/queryMatchResult.test.ts
@@ -8,6 +8,10 @@ jest.mock('@/util/debugMatchLedger', () => ({
 }))
 
 describe('queryMatchResult', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
   test('it should print the expected match result and not call debugMatchLedger when debug is false', () => {
     // Mock implementation so it does not log results
     const logSpy = jest.spyOn(console, 'log').mockImplementation(jest.fn)

--- a/src/queries/queryPlayerWinLoss.test.ts
+++ b/src/queries/queryPlayerWinLoss.test.ts
@@ -1,0 +1,84 @@
+import cases from 'jest-in-case'
+import { queryPlayerWinLoss } from './queryPlayerWinLoss'
+import { debugWinLossLedger } from '@/util/debugWinLossLedger'
+
+jest.mock('@/util/debugWinLossLedger', () => ({
+  debugWinLossLedger: jest.fn(),
+}))
+
+const INPUT_DATA = [
+  {
+    id: '01',
+    playerOne: 'Player A',
+    playerTwo: 'Player B',
+    rallyResults: new Array(8).fill('0'),
+    rallyActions: new Array(8).fill({
+      type: 'PLAYER_ONE_WIN',
+    }),
+  },
+  {
+    id: '02',
+    playerOne: 'Player A',
+    playerTwo: 'Player C',
+    rallyResults: new Array(8).fill('0'),
+    rallyActions: new Array(8).fill({
+      type: 'PLAYER_ONE_WIN',
+    }),
+  },
+  {
+    id: '03',
+    playerOne: 'Player B',
+    playerTwo: 'Player C',
+    rallyResults: new Array(8).fill('0'),
+    rallyActions: new Array(8).fill({
+      type: 'PLAYER_ONE_WIN',
+    }),
+  },
+]
+
+describe('queryPlayerWinLoss', () => {
+  beforeEach(() => {
+    jest.clearAllMocks()
+  })
+
+  cases(
+    'logs out expected win-loss ratio',
+    ({ player, output }) => {
+      // Mock implementation so it does not log results
+      const logSpy = jest.spyOn(console, 'log').mockImplementation(jest.fn)
+      queryPlayerWinLoss(INPUT_DATA, player, false)
+      expect(logSpy).toHaveBeenCalledWith(output)
+      logSpy.mockRestore()
+
+      expect(debugWinLossLedger).not.toHaveBeenCalled()
+    },
+    [
+      {
+        name: 'Player A should log out 2 0',
+        player: 'Player A',
+        output: '2 0\n',
+      },
+      {
+        name: 'Player B should log out 1 1',
+        player: 'Player B',
+        output: '1 1\n',
+      },
+      {
+        name: 'Player C should log out 0 2',
+        player: 'Player C',
+        output: '0 2\n',
+      },
+    ]
+  )
+
+  it('should invoke debugWinLossLedger when debug is true', () => {
+    // Mock implementation so it does not log results
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(jest.fn)
+    queryPlayerWinLoss(INPUT_DATA, 'Player A', true)
+    expect(logSpy).toHaveBeenCalledWith('2 0\n')
+    logSpy.mockRestore()
+
+    // Verify that the debugWinLossLedger function was called.
+    expect(debugWinLossLedger).toHaveBeenCalled()
+  })
+})

--- a/src/queries/queryPlayerWinLoss.ts
+++ b/src/queries/queryPlayerWinLoss.ts
@@ -1,0 +1,31 @@
+import type { Match } from '@/util/types'
+import { calculateMatchResult } from '@/util/calculateMatchResult'
+import { doesMatchHavePlayer } from '@/util/doesMatchHavePlayer'
+import { calculateWinLossForPlayer } from '@/util/calculateWinLossForPlayer'
+import { debugWinLossLedger } from '@/util/debugWinLossLedger'
+import { logWinLossForPlayer } from '@/util/logWinLossForPlayer'
+
+export function queryPlayerWinLoss(
+  matches: Match[],
+  targetPlayer: string,
+  debug = false
+): void {
+  const playerMatches = matches
+    .filter((match) => doesMatchHavePlayer({ match, targetPlayer }))
+    .map((match) => ({
+      matchResults: calculateMatchResult(match.rallyActions),
+      match,
+      targetPlayer,
+    }))
+
+  if (debug) {
+    debugWinLossLedger(playerMatches)
+  }
+
+  const playerMatchResults = playerMatches.reduce(calculateWinLossForPlayer, {
+    wins: 0,
+    losses: 0,
+  })
+
+  logWinLossForPlayer(playerMatchResults)
+}

--- a/src/util/calculateWinLossForPlayer.test.ts
+++ b/src/util/calculateWinLossForPlayer.test.ts
@@ -1,0 +1,62 @@
+import { calculateWinLossForPlayer } from './calculateWinLossForPlayer'
+import { WinLossInput } from './types'
+
+/**
+ * Note: In general, I might use a library to generate a random integer and test against
+ * an incremented version of that for some randomness.
+ */
+describe('calculateWinLossForPlayer', () => {
+  it('should return an that increments the wins when player is the winner', () => {
+    const acc = { wins: 2, losses: 0 }
+    const curr = {
+      matchResults: {
+        matchWinner: 0,
+        // Stub valid values for testing to satisfy type contract
+        playerOneScore: 0,
+        playerTwoScore: 0,
+        playerOneSetsWon: 0,
+        playerTwoSetsWon: 0,
+        currentScore: '',
+        history: [],
+      },
+      match: {
+        playerOne: 'Player A',
+        playerTwo: 'Player B',
+        rallyResults: [],
+        rallyActions: [],
+        id: '1',
+      },
+      targetPlayer: 'Player A',
+    } satisfies WinLossInput
+
+    const result = calculateWinLossForPlayer(acc, curr)
+    expect(result).toEqual({ wins: 3, losses: 0 })
+  })
+
+  it('should return an object that increments the losses when player is the loser', () => {
+    const acc = { wins: 3, losses: 5 }
+    const curr = {
+      matchResults: {
+        matchWinner: 1,
+        // Stub valid values for testing to satisfy type contract
+        playerOneScore: 0,
+        playerTwoScore: 0,
+        playerOneSetsWon: 0,
+        playerTwoSetsWon: 0,
+        currentScore: '',
+        history: [],
+      },
+      match: {
+        playerOne: 'Player A',
+        playerTwo: 'Player B',
+        rallyResults: [],
+        rallyActions: [],
+        id: '1',
+      },
+      targetPlayer: 'Player A',
+    } satisfies WinLossInput
+
+    const result = calculateWinLossForPlayer(acc, curr)
+    expect(result).toEqual({ wins: 3, losses: 6 })
+  })
+})

--- a/src/util/calculateWinLossForPlayer.ts
+++ b/src/util/calculateWinLossForPlayer.ts
@@ -1,6 +1,9 @@
 import { WinLoss, WinLossInput } from '@/util/types'
 
-export const calculateWinLossForPlayer = (acc: WinLoss, curr: WinLossInput) => {
+export const calculateWinLossForPlayer = (
+  acc: WinLoss,
+  curr: WinLossInput
+): WinLoss => {
   const { matchResults, match, targetPlayer } = curr
   const { playerOne } = match
 

--- a/src/util/calculateWinLossForPlayer.ts
+++ b/src/util/calculateWinLossForPlayer.ts
@@ -1,0 +1,18 @@
+import { WinLoss, WinLossInput } from '@/util/types'
+
+export const calculateWinLossForPlayer = (acc: WinLoss, curr: WinLossInput) => {
+  const { matchResults, match, targetPlayer } = curr
+  const { playerOne } = match
+
+  if (playerOne === targetPlayer && matchResults.matchWinner === 0) {
+    return {
+      wins: acc.wins + 1,
+      losses: acc.losses,
+    }
+  } else {
+    return {
+      wins: acc.wins,
+      losses: acc.losses + 1,
+    }
+  }
+}

--- a/src/util/debugWinLossLedger.ts
+++ b/src/util/debugWinLossLedger.ts
@@ -1,0 +1,39 @@
+import Table from 'cli-table'
+import { WinLossInput } from './types'
+
+/**
+ * Prints a CLI table to help debug match results.
+ * It emulates what was given in the README.
+ */
+export function debugWinLossLedger(results: WinLossInput[]) {
+  const table = new Table({
+    head: ['Game', 'Result', 'Wins', 'Losses'],
+  })
+
+  table.push([`Debugging results for ${results[0].targetPlayer}`, '', '', ''])
+
+  let wins = 0
+  let losses = 0
+
+  results.forEach((entry) => {
+    const isPlayerOne = entry.match.playerOne === entry.targetPlayer
+    const winner = entry.matchResults.matchWinner
+    const isWinner =
+      (winner === 0 && isPlayerOne) || (winner === 1 && !isPlayerOne)
+
+    if (isWinner) {
+      wins++
+    } else {
+      losses++
+    }
+
+    table.push([
+      `${entry.match.playerOne} vs ${entry.match.playerTwo}`,
+      isWinner ? 'Win' : 'Loss',
+      wins.toString(),
+      losses.toString(),
+    ])
+  })
+
+  console.log(`${table.toString()}\n`)
+}

--- a/src/util/doesMatchHavePlayer.test.ts
+++ b/src/util/doesMatchHavePlayer.test.ts
@@ -1,0 +1,33 @@
+import { doesMatchHavePlayer } from './doesMatchHavePlayer'
+
+describe('doesMatchHavePlayer', () => {
+  test('should return true if the player is in the match', () => {
+    expect(
+      doesMatchHavePlayer({
+        targetPlayer: 'Person A',
+        match: {
+          playerOne: 'Person A',
+          playerTwo: 'Person B',
+          id: '01',
+          rallyResults: [],
+          rallyActions: [],
+        },
+      })
+    ).toBe(true)
+  })
+
+  test('should return false if the player is not in the match', () => {
+    expect(
+      doesMatchHavePlayer({
+        targetPlayer: 'Person C',
+        match: {
+          playerOne: 'Person A',
+          playerTwo: 'Person B',
+          id: '01',
+          rallyResults: [],
+          rallyActions: [],
+        },
+      })
+    ).toBe(false)
+  })
+})

--- a/src/util/doesMatchHavePlayer.ts
+++ b/src/util/doesMatchHavePlayer.ts
@@ -1,0 +1,8 @@
+import { HasPlayerPredicateInput } from '@/util/types'
+
+export const doesMatchHavePlayer = ({
+  targetPlayer,
+  match,
+}: HasPlayerPredicateInput) => {
+  return match.playerOne === targetPlayer || match.playerTwo === targetPlayer
+}

--- a/src/util/logWinLossForPlayer.test.ts
+++ b/src/util/logWinLossForPlayer.test.ts
@@ -1,0 +1,14 @@
+import { logWinLossForPlayer } from './logWinLossForPlayer'
+
+describe('logWinLossForPlayer', () => {
+  it('should log expected win-loss ratio', () => {
+    // Mock implementation so it does not log results
+    const logSpy = jest.spyOn(console, 'log').mockImplementation(jest.fn)
+    logWinLossForPlayer({
+      wins: 12,
+      losses: 3,
+    })
+    expect(logSpy).toHaveBeenCalledWith('12 3\n')
+    logSpy.mockRestore()
+  })
+})

--- a/src/util/logWinLossForPlayer.ts
+++ b/src/util/logWinLossForPlayer.ts
@@ -1,0 +1,5 @@
+import { WinLoss } from '@/util/types'
+
+export function logWinLossForPlayer(playerMatchResults: WinLoss): void {
+  console.log(`${playerMatchResults.wins} ${playerMatchResults.losses}\n`)
+}

--- a/src/util/types.ts
+++ b/src/util/types.ts
@@ -29,3 +29,17 @@ export type MatchResultState = {
   rallyWinnerRawValue?: string
   matchWinner?: number
 }
+
+export type HasPlayerPredicateInput = {
+  match: Match
+  targetPlayer: string
+}
+
+export type WinLossInput = HasPlayerPredicateInput & {
+  matchResults: MatchResultState
+}
+
+export type WinLoss = {
+  wins: number
+  losses: number
+}


### PR DESCRIPTION
## Linear tickets

- [Fixes NOD-386](https://linear.app/nodular/issue/NOD-386)
- [Fixes NOD-391](https://linear.app/nodular/issue/NOD-391)
- [Fixes NOD-381](https://linear.app/nodular/issue/NOD-381)
- [Fixes NOD-380](https://linear.app/nodular/issue/NOD-380)
- [Fixes NOD-379](https://linear.app/nodular/issue/NOD-379)

See attached ticket(s) for more details.

## Branch changelog

### Features

- feat(NOD-386): wire up cli functionality [c1a98d8](https://github.com/okeeffed/tennis-results-cli/commit/c1a98d8cacbf5a377a56a0b2b72296c341a7aef3)
- feat(NOD-391): add in functionality for querying win-loss for a player [6834f1c](https://github.com/okeeffed/tennis-results-cli/commit/6834f1c5562fa11a519b03bf838c4eb89226d59d)
- feat(NOD-381): add in fn to log win-loss player ratio [ec7bedc](https://github.com/okeeffed/tennis-results-cli/commit/ec7bedc4ebf9b73300076edbd6bed3ecafb9e4b2)
- feat(NOD-391): add debug helper for calculating win loss [8861f60](https://github.com/okeeffed/tennis-results-cli/commit/8861f6001bb28720102ea61ad3281e0fb0c8fbc1)
- feat(NOD-380): add functionality to bump win-loss based on input [058aa6a](https://github.com/okeeffed/tennis-results-cli/commit/058aa6a98d666bad6ae08f0625f548dbfed807b5)
- feat(NOD-379): add functionality for doesMatchHavePlayer predicate [3c330b5](https://github.com/okeeffed/tennis-results-cli/commit/3c330b5a972cd8d0305813050a3df367b5dfa1b9)

### Fixes

- fix: cli should run from tennis-results-cli [4e97c0b](https://github.com/okeeffed/tennis-results-cli/commit/4e97c0b1a0e13c5f9c90bba6fc00677ccc7eb1ab)

### Chores

No chores reported.

### Other changes

- test: add clear all mocks before hook for queryMatchResult test [6cff9f6](https://github.com/okeeffed/tennis-results-cli/commit/6cff9f64e055a355b26130aa5e54e620997e75d2)
- refactor: alter fn signature for calculateWinLossForPlayer [22c6bc7](https://github.com/okeeffed/tennis-results-cli/commit/22c6bc722a40c4dd66398d5cdb8c44d9a435a67b)
