### PR TITLE
ci(NOD-393): publish packages to npm registry through gh actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,6 @@ jobs:
       # If it passes the tests and build, then let's just publish regardless of branch.
       # This will also fail unless a package version has been bumped.
       - name: Publish package to NPM
-        run: npm publish
+        run: npm publish --access public
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,8 @@ jobs:
       - name: Check build
         run: yarn build
 
+      # For this particular repo, I don't care if publishing happens on branches.
+      # If it passes the tests and build, then let's just publish regardless of branch.
       - run: Publish package to NPM
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
 
       # For this particular repo, I don't care if publishing happens on branches.
       # If it passes the tests and build, then let's just publish regardless of branch.
-      - run: Publish package to NPM
+      - name: Publish package to NPM
+        run: npm publish
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,7 @@ jobs:
 
       # For this particular repo, I don't care if publishing happens on branches.
       # If it passes the tests and build, then let's just publish regardless of branch.
+      # This will also fail unless a package version has been bumped.
       - name: Publish package to NPM
         run: npm publish
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,9 +28,7 @@ jobs:
         with:
           node-version: '${{ env.node_version }}'
           cache: 'yarn'
-          registry-url: 'https://npm.pkg.github.com'
-          # Defaults to the user or organization that owns the workflow file
-          scope: '@okeeffed'
+          registry-url: 'https://registry.npmjs.org'
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
@@ -68,3 +66,7 @@ jobs:
 
       - name: Check build
         run: yarn build
+
+      - run: Publish package to NPM
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,3 @@
+//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
+registry=https://registry.npmjs.org/
+always-auth=true

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@okeeffed/tennis-results-cli",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": "Dennis O'Keeffe",
   "main": "dist/index.js",
   "typings": "dist/index.d.ts",


### PR DESCRIPTION
## Linear tickets

- [Fixes NOD-393](https://linear.app/nodular/issue/NOD-393)

See attached ticket(s) for more details.

## Branch changelog

### Features

No features reported.

### Fixes

No fixes reported.

### Chores

No chores reported.

### Other changes

- ci(NOD-393): add notes on publish rules [e0da61c](https://github.com/okeeffed/tennis-results-cli/commit/e0da61cad520e1a87dc737f196bad744774ae4d1)
- ci(NOD-393): update workflow for publishing to npm [a5d48d9](https://github.com/okeeffed/tennis-results-cli/commit/a5d48d9eec729769a742aa704c4c3eed18551179)
